### PR TITLE
Refactor SMS notification flow & persist notification state in DB

### DIFF
--- a/db/docker-entrypoint-initdb.d/nabovarme.sql
+++ b/db/docker-entrypoint-initdb.d/nabovarme.sql
@@ -82,7 +82,7 @@ CREATE TABLE `accounts` (
   UNIQUE KEY `unique_idx` (`serial`,`payment_time`,`amount`,`price`),
   KEY `serial_idx` (`serial`),
   KEY `accounts_serial_idx` (`serial`)
-) ENGINE=InnoDB AUTO_INCREMENT=8000 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=8027 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -142,7 +142,7 @@ CREATE TABLE `accounts_log` (
   PRIMARY KEY (`id`),
   KEY `idx_serial_time` (`serial`,`unix_time`),
   KEY `idx_user_time` (`username`,`unix_time`)
-) ENGINE=InnoDB AUTO_INCREMENT=122 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=156 DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -188,7 +188,7 @@ CREATE TABLE `alarms` (
   `comment` longtext DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `auto_id` (`auto_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2670 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=3315 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -230,7 +230,7 @@ CREATE TABLE `command_queue` (
   `timeout` int(11) NOT NULL DEFAULT 0,
   `sent_count` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=843566896 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=844941827 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -247,7 +247,7 @@ CREATE TABLE `log` (
   `param` varchar(256) DEFAULT NULL,
   `unix_time` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=53595059 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=53629512 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -295,9 +295,6 @@ CREATE TABLE `meters` (
   `email_notification` varchar(256) DEFAULT NULL,
   `sms_notification` varchar(256) DEFAULT NULL,
   `close_notification_time` int(11) DEFAULT 604800 COMMENT 'send notice this many seconds before we close (default 7 days)',
-  `notification_state` tinyint(1) unsigned NOT NULL DEFAULT 0,
-  `last_notification_sent_time` int(11) DEFAULT NULL,
-  `last_paid_kwh_marker` float DEFAULT NULL,
   `wifi_status` varchar(32) DEFAULT 'disconnected',
   `wifi_set_ssid` varchar(32) DEFAULT NULL,
   `wifi_set_pwd` varchar(64) DEFAULT NULL,
@@ -330,6 +327,7 @@ CREATE TABLE `meters_state` (
   `notification_state` tinyint(1) unsigned DEFAULT 0,
   `last_notification_sent_time` int(11) DEFAULT NULL,
   `last_paid_kwh_marker` float DEFAULT NULL,
+  `last_close_warning_kwh_marker` float DEFAULT NULL,
   `kwh_remaining` float DEFAULT NULL,
   `time_remaining_hours` float DEFAULT NULL,
   `time_remaining_hours_string` varchar(32) DEFAULT '∞',
@@ -341,7 +339,7 @@ CREATE TABLE `meters_state` (
   `last_updated` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `serial` (`serial`)
-) ENGINE=InnoDB AUTO_INCREMENT=6565815 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=18725298 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -370,7 +368,7 @@ CREATE TABLE `samples` (
   KEY `serial_unix_time_idx` (`serial`,`unix_time`),
   KEY `serial_time_spike_idx` (`serial`,`unix_time`,`is_spike`),
   KEY `spike_serial_unix_time_idx` (`serial`,`is_spike`,`unix_time`)
-) ENGINE=InnoDB AUTO_INCREMENT=813480369 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=814444227 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -399,7 +397,7 @@ CREATE TABLE `samples_cache` (
   KEY `serial_unix_time_idx` (`serial`,`unix_time`),
   KEY `spike_serial_unix_time_idx` (`serial`,`is_spike`,`unix_time`),
   KEY `samples_cache_serial_unix_id_idx` (`serial`,`unix_time`,`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=813230930 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=814194788 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -425,7 +423,7 @@ CREATE TABLE `samples_daily` (
   `unix_time` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `serial_unix_time_idx` (`serial`,`unix_time`)
-) ENGINE=InnoDB AUTO_INCREMENT=773875431 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=773877807 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -451,7 +449,7 @@ CREATE TABLE `samples_hourly` (
   `unix_time` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `serial_unix_time_idx` (`serial`,`unix_time`)
-) ENGINE=InnoDB AUTO_INCREMENT=973753223 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=973774917 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -474,7 +472,7 @@ CREATE TABLE `sms_auth` (
   `user_agent` longtext DEFAULT NULL,
   `unix_time` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2333840 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2338070 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -491,7 +489,7 @@ CREATE TABLE `sms_messages` (
   `message` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
   `unix_time` int(11) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1960808 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1961107 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -513,7 +511,7 @@ CREATE TABLE `users` (
   `meter_id` int(255) DEFAULT NULL,
   `comment` varchar(256) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=101 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=102 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -542,7 +540,7 @@ CREATE TABLE `wifi_scan` (
   KEY `serial_unix_time_idx` (`serial`,`unix_time`),
   KEY `ssid_idx` (`ssid`),
   KEY `unix_time_idx` (`unix_time`)
-) ENGINE=InnoDB AUTO_INCREMENT=451184283 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=451495131 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -554,4 +552,4 @@ CREATE TABLE `wifi_scan` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2026-01-02 14:34:44
+-- Dump completed on 2026-01-05 23:39:49


### PR DESCRIPTION
## Summary
This PR refactors the SMS notification logic to rely on persisted meter state
in the database instead of recalculating notification state at runtime.
It also cleans up schema responsibilities between `meters` and `meters_state`,
improves determinism of notifications, and updates the DB dump to reflect
current production state.

## Key changes

### Database
- Moved notification-related fields out of `meters` and into `meters_state`:
  - `notification_state`
  - `last_notification_sent_time`
  - `last_paid_kwh_marker`
- Added `last_close_warning_kwh_marker` to `meters_state` for future close warning tracking.
- Updated `AUTO_INCREMENT` values in the SQL dump to reflect the latest database snapshot.
- Updated dump timestamp.

### SMS notification logic (`meter_notify.pl`)
- Removed dependency on `Nabovarme::EnergyEstimator` for notification decisions.
- Notification decisions are now driven directly from:
  - `meters_state.kwh_remaining`
  - `meters_state.time_remaining_hours`
  - persisted notification state fields.
- Introduced a clearer **state machine**:
  - `0` → normal
  - `1` → close warning sent
  - `2` → close notice sent
- Added explicit top-up detection using `paid_kwh` with hysteresis.
- Prevents duplicate SMS sends by persisting `last_notification_sent_time`.
- Environment variables renamed for clarity:
  - `NOTIFICATION_UP_MESSAGE`
  - `NOTIFICATION_DOWN_MESSAGE`
  - `NOTIFICATION_CLOSE_WARNING_MESSAGE`
  - `NOTIFICATION_CLOSE_WARNING_TIME`
- Improved logging and startup message clarity.

### EnergyEstimator
- Always loads notification/state fields from `meters_state` first.
- Cache values now only overwrite defaults if defined.
- Ensures estimator results are consistent with persisted notification state.

## Behavior changes and notes
- Notification state is now authoritative in the database, making restarts safe and idempotent.
- SMS messages are only sent once per state transition or top-up.
- Close warnings and close notices are strictly ordered and reversible when energy or time recovers.
- Requires `meters_state` to be present and populated for active meters.

## Why this change?
- Prevent duplicate or missed SMS notifications.
- Make notification behavior deterministic and restart-safe.
- Clearly separate *configuration* (`meters`) from *runtime state* (`meters_state`).
- Reduce coupling between estimation logic and notification delivery.
